### PR TITLE
Add configurable max upload size.

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
   runtimeOnly("org.glassfish.jersey.inject:jersey-hk2:3.0.8")
   implementation("org.glassfish.hk2:hk2-api:3.0.3")
 
-  implementation("com.fasterxml.jackson.core:jackson-databind:2.13.4.1")
+  implementation("com.fasterxml.jackson.core:jackson-databind:2.13.4")
   implementation("com.fasterxml.jackson.core:jackson-annotations:2.13.4")
 
   testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.0")

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -23,14 +23,14 @@ dependencies {
   implementation(kotlin("stdlib-jdk7"))
   implementation(kotlin("stdlib-jdk8"))
 
-  implementation("commons-fileupload:commons-fileupload:1.4")
+  implementation("commons-fileupload:commons-fileupload:1.5")
 
   implementation("org.glassfish.jersey.containers:jersey-container-grizzly2-http:3.0.8")
   implementation("org.glassfish.jersey.containers:jersey-container-grizzly2-servlet:3.0.8")
   runtimeOnly("org.glassfish.jersey.inject:jersey-hk2:3.0.8")
   implementation("org.glassfish.hk2:hk2-api:3.0.3")
 
-  implementation("com.fasterxml.jackson.core:jackson-databind:2.13.4")
+  implementation("com.fasterxml.jackson.core:jackson-databind:2.13.4.1")
   implementation("com.fasterxml.jackson.core:jackson-annotations:2.13.4")
 
   testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.0")

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "org.veupathdb.lib"
-version = "1.0.2"
+version = "1.1.0"
 
 repositories {
   mavenCentral()

--- a/lib/src/main/java/org/veupathdb/lib/jaxrs/raml/multipart/JaxRSMultipartUpload.kt
+++ b/lib/src/main/java/org/veupathdb/lib/jaxrs/raml/multipart/JaxRSMultipartUpload.kt
@@ -1,0 +1,23 @@
+package org.veupathdb.lib.jaxrs.raml.multipart
+
+/**
+ * JaxRS Multipart Upload Global Configuration
+ */
+object JaxRSMultipartUpload {
+
+  /**
+   * Maximum allowed size for a file upload (in bytes).
+   *
+   * Defaults to 3GiB.
+   */
+  @JvmStatic
+  var maxFileUploadSize = 3_221_225_472L
+
+  /**
+   * Maximum allowed size for an in-memory field, class, or property (in bytes).
+   *
+   * Defaults to 16MiB.
+   */
+  @JvmStatic
+  var maxInMemoryFieldSize = 16_777_216L
+}

--- a/lib/src/main/java/org/veupathdb/lib/jaxrs/raml/multipart/MultipartMessageBodyReader.kt
+++ b/lib/src/main/java/org/veupathdb/lib/jaxrs/raml/multipart/MultipartMessageBodyReader.kt
@@ -231,7 +231,7 @@ class MultipartMessageBodyReader : MessageBodyReader<Any> {
         // field.
         val file = File(tmpDir, fileName).apply {
           createNewFile()
-          outputStream().use { stream.readBodyData(it) }
+          CappedOutputStream(JaxRSMultipartUpload.maxFileUploadSize, outputStream()).use { stream.readBodyData(it) }
         }
 
         // Assign the file value to our temp map.

--- a/lib/src/main/java/org/veupathdb/lib/jaxrs/raml/multipart/MultipartMessageBodyReader.kt
+++ b/lib/src/main/java/org/veupathdb/lib/jaxrs/raml/multipart/MultipartMessageBodyReader.kt
@@ -144,7 +144,7 @@ class MultipartMessageBodyReader : MessageBodyReader<Any> {
       // Attempt to read the first part of the body as the generic type defined by
       // the constructor method's input parameter.
       val inp = mapper.convertValue<Any>(
-        stream.readContentAsJsonNode(JaxRSMultipartUpload.maxInMemoryFieldSize),
+        stream.readContentAsJsonNode(maxVariableSize),
         mapper.typeFactory.constructType(constructor.genericParameterTypes[0])
       )
 

--- a/lib/src/main/java/org/veupathdb/lib/jaxrs/raml/multipart/utils/CappedOutputStream.kt
+++ b/lib/src/main/java/org/veupathdb/lib/jaxrs/raml/multipart/utils/CappedOutputStream.kt
@@ -7,10 +7,10 @@ import java.io.OutputStream
  * Capped Size Output Stream
  *
  * A simple output stream wrapper that throws an exception if more than the
- * specified max number of bytes is read.
+ * specified max number of bytes is written.
  */
 class CappedOutputStream(
-  private val maxBytes: Int,
+  private val maxBytes: Long,
   private val stream: OutputStream
 ) : OutputStream() {
   private var written = 0

--- a/lib/src/main/java/org/veupathdb/lib/jaxrs/raml/multipart/utils/apache.kt
+++ b/lib/src/main/java/org/veupathdb/lib/jaxrs/raml/multipart/utils/apache.kt
@@ -14,9 +14,11 @@ private const val LCContentDisp  = "content-disposition"
 private const val FormNamePrefix = "name="
 private const val FileNamePrefix = "filename="
 
+private const val InitialBufferSize = 8192
 
-internal fun MultipartStream.contentToString(maxSize: Int) =
-  ByteArrayOutputStream(8192).let {
+
+internal fun MultipartStream.contentToString(maxSize: Long) =
+  ByteArrayOutputStream(InitialBufferSize).let {
     if (readBodyData(CappedOutputStream(maxSize, it)) == 0)
       ""
     else
@@ -47,7 +49,7 @@ internal fun String?.parseHeaders(): Map<String, List<String>> {
   return out
 }
 
-internal fun MultipartStream.readContentAsJsonNode(maxSize: Int) =
+internal fun MultipartStream.readContentAsJsonNode(maxSize: Long) =
   contentToString(maxSize).let {
     try {
       MultipartMessageBodyReader.mapper.readTree(it)

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -27,15 +27,15 @@ dependencies {
 
   implementation(project(":multipart-jackson-pojo"))
 
-  implementation("commons-fileupload:commons-fileupload:1.4")
+  implementation("commons-fileupload:commons-fileupload:1.5")
 
   implementation("org.glassfish.jersey.containers:jersey-container-grizzly2-http:3.0.6")
   implementation("org.glassfish.jersey.containers:jersey-container-grizzly2-servlet:3.0.6")
   runtimeOnly("org.glassfish.jersey.inject:jersey-hk2:3.0.6")
   implementation("org.glassfish.hk2:hk2-api:3.0.3")
 
-  implementation("com.fasterxml.jackson.core:jackson-databind:2.13.3")
-  implementation("com.fasterxml.jackson.core:jackson-annotations:2.13.3")
+  implementation("com.fasterxml.jackson.core:jackson-databind:2.13.4")
+  implementation("com.fasterxml.jackson.core:jackson-annotations:2.13.4")
 
   testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.0")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.0")


### PR DESCRIPTION
**Changes**:

* Add configuration option for max file upload size (defaults to 3GiB)
* Moves configuration option for max in-memory field size to configuration object.
* Deprecates old in-memory field size max option